### PR TITLE
Update bootstrap script

### DIFF
--- a/ansible/files/telemetry.sh
+++ b/ansible/files/telemetry.sh
@@ -1,3 +1,9 @@
+# logging for any errors during bootstrapping
+exec >> /var/log/bootstrap-script.log
+exec 2>&1
+
+# we won't use `set -e` because that means that AWS would terminate the instance and we wouldn't get logs for why it failed
+
 TELEMETRY_CONF_BUCKET=s3://telemetry-spark-emr-2
 MEMORY_OVERHEAD=7000  # Tuned for c3.4xlarge
 EXECUTOR_MEMORY=15000M
@@ -9,7 +15,8 @@ sudo yum-config-manager --enable epel
 
 # Install packages
 curl https://bintray.com/sbt/rpm/rpm | sudo tee /etc/yum.repos.d/bintray-sbt-rpm.repo
-sudo yum -y install git jq htop tmux libffi-devel aws-cli postgresql-devel zsh snappy-devel readline-devel sbt emacs
+sudo yum -y install git jq htop tmux libffi-devel aws-cli postgresql-devel zsh snappy-devel readline-devel emacs
+sudo yum -y install --nogpgcheck sbt # bintray doesn't sign packages for some reason, this isn't ideal but is the only way to install sbt
 
 # Download jars
 aws s3 sync $TELEMETRY_CONF_BUCKET/jars $HOME/jars
@@ -45,9 +52,10 @@ done
 
 # Setup Python
 export ANACONDAPATH=$HOME/anaconda2
-wget -nc https://3230d63b5fc54e62148e-c95ac804525aac4b6dba79b00b39d1d3.ssl.cf1.rackcdn.com/Anaconda2-2.5.0-Linux-x86_64.sh
+wget --no-clobber --no-verbose https://3230d63b5fc54e62148e-c95ac804525aac4b6dba79b00b39d1d3.ssl.cf1.rackcdn.com/Anaconda2-2.5.0-Linux-x86_64.sh
 bash Anaconda2-2.5.0-Linux-x86_64.sh -b
 $ANACONDAPATH/bin/pip install python_moztelemetry python_mozaggregator montecarlino jupyter-notebook-gist runipy boto3 parquet2hive py4j==0.8.2.1 pyliblzma==0.5.3 plotly==1.6.16 seaborn==0.6.0
+rm Anaconda2-2.5.0-Linux-x86_64.sh
 
 # Add public key
 if [ -n "$PUBLIC_KEY" ]; then
@@ -67,6 +75,7 @@ fi
 # Setup R environment
 wget -nc https://mran.revolutionanalytics.com/install/RRO-3.2.1-el6.x86_64.tar.gz
 tar -xzf RRO-3.2.1-el6.x86_64.tar.gz
+rm RRO-3.2.1-el6.x86_64.tar.gz
 cd RRO-3.2.1; sudo ./install.sh; cd ..
 $ANACONDAPATH/bin/pip install rpy2
 mkdir -p $HOME/R_libs

--- a/ansible/files/telemetry.sh
+++ b/ansible/files/telemetry.sh
@@ -15,7 +15,7 @@ sudo yum-config-manager --enable epel
 
 # Install packages
 curl https://bintray.com/sbt/rpm/rpm | sudo tee /etc/yum.repos.d/bintray-sbt-rpm.repo
-sudo yum -y install git jq htop tmux libffi-devel aws-cli postgresql-devel zsh snappy-devel readline-devel emacs
+sudo yum -y install git jq htop tmux libffi-devel aws-cli postgresql-devel zsh snappy-devel readline-devel emacs nethogs w3m
 sudo yum -y install --nogpgcheck sbt # bintray doesn't sign packages for some reason, this isn't ideal but is the only way to install sbt
 
 # Download jars


### PR DESCRIPTION
This is already updated on S3 in order to fix ATMO. SBT package was breaking all the other install steps due to some subtle Bintray changes. I haven't looked into it too closely, but I think Bintray updated the way they disable GPG sig checking for their packages.

Also, there's a bunch more changes because the version in this repo is out of date with the version we're actually using in prod.
