### PR TITLE
Change RRO download to point at correct domain

### DIFF
--- a/ansible/files/telemetry.sh
+++ b/ansible/files/telemetry.sh
@@ -98,7 +98,7 @@ sudo chmod a+rw /mnt/var/log/spark
 touch /mnt/var/log/spark/spark.log
 
 # Setup R environment
-wget -nc https://mran.revolutionanalytics.com/install/RRO-3.2.1-el6.x86_64.tar.gz
+wget -nc https://mran.microsoft.com/install/RRO-3.2.1-el6.x86_64.tar.gz
 tar -xzf RRO-3.2.1-el6.x86_64.tar.gz
 rm RRO-3.2.1-el6.x86_64.tar.gz
 cd RRO-3.2.1; sudo ./install.sh; cd ..


### PR DESCRIPTION
It appears that microsoft migrated the mran domain to mran.microsoft.com but didn't get redirects setup properly. All the google links to the docs pages and such are broken as well.