### PR TITLE
Fix notebook conversion for batch execution

### DIFF
--- a/ansible/files/batch.sh
+++ b/ansible/files/batch.sh
@@ -75,7 +75,7 @@ else
 
     NOTEBOOK_NAME=${NOTEBOOK##*/}
     PYSPARK_DRIVER_PYTHON=jupyter \
-    PYSPARK_DRIVER_PYTHON_OPTS="nbconvert --to python --log-level=10 --execute ../${NOTEBOOK_NAME} --allow-errors --output ${NOTEBOOK_NAME}" \
+    PYSPARK_DRIVER_PYTHON_OPTS="nbconvert --to notebook --log-level=10 --execute ../${NOTEBOOK_NAME} --allow-errors --output ${NOTEBOOK_NAME}" \
     pyspark
     EXIT_CODE=$?
     if [ $EXIT_CODE != 0 ] || [ "`grep  '\"output_type\": \"error\"' $NOTEBOOK_NAME`" ] ;then


### PR DESCRIPTION
The notebook needs to be converted to another notebook in order to grep the error metadata and detect eventual failures

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/emr-bootstrap-spark/41)
<!-- Reviewable:end -->
