### PR TITLE
Bug 1306036 - Fix typesafe repo / bintray 404 when running sbt

### DIFF
--- a/ansible/files/telemetry.sh
+++ b/ansible/files/telemetry.sh
@@ -19,6 +19,7 @@ sudo yum-config-manager --enable epel
 curl https://bintray.com/sbt/rpm/rpm | sudo tee /etc/yum.repos.d/bintray-sbt-rpm.repo
 sudo yum -y install git jq htop tmux libffi-devel aws-cli postgresql-devel zsh snappy-devel readline-devel emacs nethogs w3m
 sudo yum -y install --nogpgcheck sbt # bintray doesn't sign packages for some reason, this isn't ideal but is the only way to install sbt
+aws s3 sync $TELEMETRY_CONF_BUCKET/sbt $HOME # this fixes bintray 404s, ideally a temporary fix
 
 # Download jars
 aws s3 sync $TELEMETRY_CONF_BUCKET/jars $HOME/jars


### PR DESCRIPTION
We've mirrored a clean copy of .ivy2 and .sbt to our s3 bucket. This uses `s3 sync` to download those files to the home directory which bypasses the 404s we were seeing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/emr-bootstrap-spark/42)
<!-- Reviewable:end -->
