### PR TITLE
Bug 	1337539 - Add option to mount EFS on $HOME

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -33,3 +33,34 @@
       include: render_and_copy_to_s3.yml file={{item}} permission="public-read"
       with_items:
         - configuration/configuration.json
+
+    - name: EFS security group in region us-west-2
+      local_action:
+        module: ec2_group
+        name: atmo-efs-access
+        description: EFS Access
+        region: us-west-2
+        rules:
+          - proto: tcp
+            from_port: 2049
+            to_port: 2049
+            group_name: ElasticMapReduce-master
+          - proto: tcp
+            from_port: 2049
+            to_port: 2049
+            group_name: ElasticMapReduce-slave
+      register: efs_access
+
+    - name: create EFS volume
+      efs:
+        state: present
+        name: ATMO-prod 
+        tags:
+            app: telemetry-analysis
+        targets:
+            - subnet_id: subnet-63f72706
+              security_groups: [ "{{ efs_access.group_id }}" ]
+            - subnet_id: subnet-4228de35
+              security_groups: [ "{{ efs_access.group_id }}" ]
+            - subnet_id: subnet-b2c3d5f4
+              security_groups: [ "{{ efs_access.group_id }}" ]

--- a/ansible/envs/dev.yml
+++ b/ansible/envs/dev.yml
@@ -3,4 +3,4 @@ telemetry_analysis_code_bucket: telemetry-analysis-code-2
 telemetry_analysis_spark_emr_bucket: telemetry-spark-emr-2
 telemetry_analysis_public_bucket: telemetry-public-analysis-2
 telemetry_analysis_private_bucket: telemetry-private-analysis-2
-telemetry_analysis_anaconda_path: /home/hadoop/anaconda2
+telemetry_analysis_anaconda_path: /mnt/anaconda2

--- a/ansible/files/bootstrap/telemetry.sh
+++ b/ansible/files/bootstrap/telemetry.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-cp -r /home/hadoop /mnt
-sudo mount --bind --verbose /mnt/hadoop /home/hadoop
-
 # logging for any errors during bootstrapping
 exec > >(tee -i /var/log/bootstrap-script.log)
 exec 2>&1
@@ -10,10 +7,109 @@ exec 2>&1
 # we won't use `set -e` because that means that AWS would terminate the instance and we wouldn't get logs for why it failed
 
 TELEMETRY_CONF_BUCKET=s3://{{telemetry_analysis_spark_emr_bucket}}
+
+# Check for master node
+IS_MASTER=true
+if [ -f /mnt/var/lib/info/instance.json ]
+then
+    IS_MASTER=$(jq .isMaster /mnt/var/lib/info/instance.json)
+fi
+
+# Parse arguments
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --public-key)
+            shift
+            PUBLIC_KEY=$1
+            ;;
+        --timeout)
+            shift
+            TIMEOUT=$1
+            ;;
+        --email)
+            shift
+            EMAIL=$1
+            ;;
+        --efs-dns)
+            shift
+            EFS_DNS=$1
+            ;;
+        -*)
+            # do not exit out, just note failure
+            echo 1>&2 "unrecognized option: $1"
+            ;;
+        *)
+            break;
+            ;;
+    esac
+    shift
+done
+
+
+CURRENT_KEY=`cat $HOME/.ssh/authorized_keys`
+TELEMETRY_CONF_BUCKET=s3://{{telemetry_analysis_spark_emr_bucket}}
 MEMORY_OVERHEAD=7000  # Tuned for c3.4xlarge
 EXECUTOR_MEMORY=15000M
 DRIVER_MIN_HEAP=1000M
 DRIVER_MEMORY=$EXECUTOR_MEMORY
+SETUP_HOME_DIR=false
+
+#EFS Mounting - only on master
+if [ -n "$EMAIL" ] && [ -n "$EFS_DNS" ] && "$IS_MASTER" ; then
+    # Mount entire efs locally to check for user's dir
+    mkdir -p /mnt/efs
+    sudo mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 "$EFS_DNS:/" /mnt/efs
+
+    if [ ! -d "/mnt/efs/$EMAIL" ]; then
+        # If no dir for this user, create it
+        SETUP_HOME_DIR=true
+        sudo mkdir -p "/mnt/efs/$EMAIL"
+    fi
+
+    sudo mkdir -p "/mnt/efs/$EMAIL/analyses"
+    sudo mkdir -p "/mnt/efs/$EMAIL/.ssh"
+
+    AUTH_KEYS_FILE="/mnt/efs/$EMAIL/.ssh/authorized_keys"
+    sudo test -e "$AUTH_KEYS_FILE" || sudo touch "$AUTH_KEYS_FILE"
+
+    # mount user's EFS dir on $HOME
+    sudo mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 "$EFS_DNS:/$EMAIL" "$HOME"
+
+    # Set ownership of user dir
+    sudo chown --recursive hadoop:hadoop "$HOME"
+
+    # allow Jupyter to access analyses dir
+    sudo chmod --recursive a+rw "$HOME/analyses"
+
+    # fixes ssh access
+    sudo chmod go-w "$HOME"
+    sudo chmod 700 "$HOME/.ssh"
+    sudo chmod 700 "$HOME/.ssh/authorized_keys"
+
+elif "$IS_MASTER" ; then
+    mkdir -p $HOME/analyses
+    SETUP_HOME_DIR=true
+fi
+
+if [ "$SETUP_HOME_DIR" = true ] ; then
+    # Only execute this when using EFS and this is a new user, or when not using EFS
+
+    # Download examples to analyses dir
+    wget -nc -P "$HOME/analyses" https://raw.githubusercontent.com/mozilla/mozilla-reports/master/tutorials/telemetry_hello_world.kp/orig_src/Telemetry%20Hello%20World.ipynb
+    wget -nc -P "$HOME/analyses" https://raw.githubusercontent.com/mozilla/mozilla-reports/master/tutorials/longitudinal_dataset.kp/orig_src/Longitudinal%20Dataset%20Tutorial.ipynb
+    wget -nc -P "$HOME/analyses" https://raw.githubusercontent.com/mozilla/mozilla-reports/master/examples/new_report.kp/orig_src/New%2BReport.ipynb
+
+    aws s3 sync $TELEMETRY_CONF_BUCKET/sbt $HOME # this fixes bintray 404s
+    aws s3 sync $TELEMETRY_CONF_BUCKET/jars $HOME/jars
+
+    mkdir -p $HOME/R_libs
+
+    # Setup plotly
+    mkdir -p $HOME/.plotly && aws s3 cp $TELEMETRY_CONF_BUCKET/plotly_credentials $HOME/.plotly/.credentials
+
+    # Setup Jupyter notebook
+    aws s3 cp $TELEMETRY_CONF_BUCKET/bootstrap/jupyter_notebook_config.py ~/.jupyter/jupyter_notebook_config.py
+fi
 
 # Enable EPEL
 mirror="https://s3-us-west-2.amazonaws.com/net-mozaws-prod-us-west-2-ops-rpmrepo-mirror"
@@ -39,45 +135,13 @@ sudo yum makecache
 curl https://bintray.com/sbt/rpm/rpm | sudo tee /etc/yum.repos.d/bintray-sbt-rpm.repo
 sudo yum -y install git jq htop tmux libffi-devel aws-cli postgresql-devel zsh snappy-devel readline-devel emacs nethogs w3m
 sudo yum -y install --nogpgcheck sbt # bintray doesn't sign packages for some reason, this isn't ideal but is the only way to install sbt
-aws s3 sync $TELEMETRY_CONF_BUCKET/sbt $HOME # this fixes bintray 404s, ideally a temporary fix
-
-# Download jars
-aws s3 sync $TELEMETRY_CONF_BUCKET/jars $HOME/jars
-
-# Check for master node
-IS_MASTER=true
-if [ -f /mnt/var/lib/info/instance.json ]
-then
-    IS_MASTER=$(jq .isMaster /mnt/var/lib/info/instance.json)
-fi
-
-# Parse arguments
-while [ $# -gt 0 ]; do
-    case "$1" in
-        --public-key)
-            shift
-            PUBLIC_KEY=$1
-            ;;
-        --timeout)
-            shift
-            TIMEOUT=$1
-            ;;
-        -*)
-            # do not exit out, just note failure
-            echo 1>&2 "unrecognized option: $1"
-            ;;
-        *)
-            break;
-            ;;
-    esac
-    shift
-done
 
 # Setup Python
-export ANACONDAPATH={{telemetry_analysis_anaconda_path}}
+export ANACONDA_PATH={{telemetry_analysis_anaconda_path}}
+
 ANACONDA_SCRIPT=Anaconda2-4.2.0-Linux-x86_64.sh
-wget --no-clobber --no-verbose http://repo.continuum.io/archive/$ANACONDA_SCRIPT
-bash $ANACONDA_SCRIPT -b
+wget --no-clobber --no-verbose -P /mnt http://repo.continuum.io/archive/$ANACONDA_SCRIPT
+bash /mnt/$ANACONDA_SCRIPT -b -p $ANACONDA_PATH
 
 PIP_REQUIREMENTS_FILE=/tmp/requirements.txt
 cat << EOF > $PIP_REQUIREMENTS_FILE
@@ -93,13 +157,20 @@ pyliblzma==0.5.3
 plotly==1.6.16
 seaborn==0.6.0
 EOF
-$ANACONDAPATH/bin/pip install -r $PIP_REQUIREMENTS_FILE
-rm $ANACONDA_SCRIPT
+
+$ANACONDA_PATH/bin/pip install -r $PIP_REQUIREMENTS_FILE
+rm /mnt/$ANACONDA_SCRIPT
 rm $PIP_REQUIREMENTS_FILE
 
-# Add public key
-if [ -n "$PUBLIC_KEY" ]; then
-    echo $PUBLIC_KEY >> $HOME/.ssh/authorized_keys
+# Add public key if it's not currently there
+AUTH_KEYS_PATH="$HOME/.ssh/authorized_keys"
+
+if [ -n "$PUBLIC_KEY" ] && ! sudo grep -q "$PUBLIC_KEY" "$AUTH_KEYS_PATH" ; then
+    sudo echo $PUBLIC_KEY | sudo dd of="$AUTH_KEYS_PATH"
+fi
+
+if ! sudo grep -q "$CURRENT_KEY" "$AUTH_KEYS_PATH" ; then
+    sudo echo "$CURRENT_KEY" | sudo dd of="$AUTH_KEYS_PATH"
 fi
 
 # Schedule shutdown at timeout
@@ -118,38 +189,40 @@ sudo chmod a+rw /mnt/var/log/spark
 touch /mnt/var/log/spark/spark.log
 
 # Setup R environment
+cd /mnt
 wget -nc https://mran.microsoft.com/install/RRO-3.2.1-el6.x86_64.tar.gz
 tar -xzf RRO-3.2.1-el6.x86_64.tar.gz
 rm RRO-3.2.1-el6.x86_64.tar.gz
-cd RRO-3.2.1; sudo ./install.sh; cd ..
-$ANACONDAPATH/bin/pip install rpy2
-mkdir -p $HOME/R_libs
+cd RRO-3.2.1; sudo ./install.sh; cd $HOME
+$ANACONDA_PATH/bin/pip install rpy2
+
+# Setup global bash file
+# .sh files in /etc/profile.d/ run whenever a user logs in
+GLOBAL_BASHRC=/etc/profile.d/atmo.sh
+sudo touch "$GLOBAL_BASHRC"
+sudo chown hadoop:hadoop "$GLOBAL_BASHRC"
+sudo chmod 700 "$GLOBAL_BASHRC"
 
 # Configure environment variables
-echo "" >> $HOME/.bashrc
-echo "export R_LIBS=$HOME/R_libs" >> $HOME/.bashrc
-echo "export LD_LIBRARY_PATH=/usr/lib64/RRO-3.2.1/R-3.2.1/lib64/R/lib/" >> $HOME/.bashrc
-echo "export PYTHONPATH=/usr/lib/spark/python/" >> $HOME/.bashrc
-echo "export SPARK_HOME=/usr/lib/spark" >> $HOME/.bashrc
-echo "export PYSPARK_PYTHON=$ANACONDAPATH/bin/python" >> $HOME/.bashrc
-echo "export PYSPARK_DRIVER_PYTHON=jupyter" >> $HOME/.bashrc
-echo "export PYSPARK_DRIVER_PYTHON_OPTS=console" >> $HOME/.bashrc
-echo "export PATH=$ANACONDAPATH/bin:\$PATH" >> $HOME/.bashrc
-echo "export _JAVA_OPTIONS=\"-Djava.io.tmpdir=/mnt1/ -Xmx$DRIVER_MEMORY -Xms$DRIVER_MIN_HEAP\"" >> $HOME/.bashrc
-echo "export PYSPARK_SUBMIT_ARGS=\"--packages com.databricks:spark-csv_2.10:1.2.0 --master yarn --deploy-mode client --executor-memory $EXECUTOR_MEMORY --conf spark.yarn.executor.memoryOverhead=$MEMORY_OVERHEAD pyspark-shell\"" >> $HOME/.bashrc
+sudo echo "" >> "$GLOBAL_BASHRC"
+sudo echo "export R_LIBS=$HOME/R_libs" >> "$GLOBAL_BASHRC"
+sudo echo "export LD_LIBRARY_PATH=/usr/lib64/RRO-3.2.1/R-3.2.1/lib64/R/lib/" >> "$GLOBAL_BASHRC"
+sudo echo "export PYTHONPATH=/usr/lib/spark/python/" >> "$GLOBAL_BASHRC"
+sudo echo "export SPARK_HOME=/usr/lib/spark" >> "$GLOBAL_BASHRC"
+sudo echo "export PYSPARK_PYTHON=$ANACONDA_PATH/bin/python" >> "$GLOBAL_BASHRC"
+sudo echo "export PYSPARK_DRIVER_PYTHON=jupyter" >> "$GLOBAL_BASHRC"
+sudo echo "export PYSPARK_DRIVER_PYTHON_OPTS=console" >> "$GLOBAL_BASHRC"
+sudo echo "export PATH=$ANACONDA_PATH/bin:\$PATH" >> "$GLOBAL_BASHRC"
+sudo echo "export _JAVA_OPTIONS=\"-Djava.io.tmpdir=/mnt1/ -Xmx$DRIVER_MEMORY -Xms$DRIVER_MIN_HEAP\"" >> "$GLOBAL_BASHRC"
+sudo echo "export PYSPARK_SUBMIT_ARGS=\"--packages com.databricks:spark-csv_2.10:1.2.0 --master yarn --deploy-mode client --executor-memory $EXECUTOR_MEMORY --conf spark.yarn.executor.memoryOverhead=$MEMORY_OVERHEAD pyspark-shell\"" >> "$GLOBAL_BASHRC"
 
-source $HOME/.bashrc
+source "$GLOBAL_BASHRC"
 
-# Setup Jupyter notebook
-aws s3 cp $TELEMETRY_CONF_BUCKET/bootstrap/jupyter_notebook_config.py ~/.jupyter/jupyter_notebook_config.py
-
-# Setup plotly
-mkdir -p $HOME/.plotly && aws s3 cp $TELEMETRY_CONF_BUCKET/plotly_credentials $HOME/.plotly/.credentials
 
 # Load Parquet datasets after Hive metastore is up
 HIVE_CONFIG_SCRIPT=$(cat <<EOF
 while ! echo exit | nc localhost 9083; do sleep 5; done
-/home/hadoop/anaconda2/bin/parquet2hive s3://telemetry-parquet/longitudinal --use-last-versions 5 | bash
+$ANACONDA_PATH/bin/parquet2hive s3://telemetry-parquet/longitudinal --use-last-versions 5 | bash
 exit 0
 EOF
 )
@@ -169,10 +242,7 @@ jupyter nbextension install --py jupyter_spark --user
 jupyter nbextension enable --py jupyter_spark --user
 
 # Launch Jupyter Notebook
-mkdir -p $HOME/analyses && cd $HOME/analyses
-wget -nc https://raw.githubusercontent.com/mozilla/mozilla-reports/master/tutorials/telemetry_hello_world.kp/orig_src/Telemetry%20Hello%20World.ipynb
-wget -nc https://raw.githubusercontent.com/mozilla/mozilla-reports/master/tutorials/longitudinal_dataset.kp/orig_src/Longitudinal%20Dataset%20Tutorial.ipynb
-wget -nc https://raw.githubusercontent.com/mozilla/mozilla-reports/master/examples/new_report.kp/orig_src/New%2BReport.ipynb
+cd $HOME/analyses
 
 cat << EOF > /tmp/run_jupyter.sh
 #!/bin/bash

--- a/ansible/render_and_copy_to_s3.yml
+++ b/ansible/render_and_copy_to_s3.yml
@@ -4,9 +4,11 @@
       register: temp
 
     - name: render template
+      when: temp.stdout is defined
       template: src={{playbook_dir}}/files/{{file}} dest={{temp.stdout}}
 
     - name: upload template
+      when: temp.stdout is defined
       s3:
         bucket: "{{telemetry_analysis_spark_emr_bucket}}"
         region: "{{telemetry_analysis_region}}"
@@ -17,4 +19,5 @@
 
   always:
       - name: clean up temp file
+        when: temp.stdout is defined
         file: path={{ temp.stdout }} state=absent


### PR DESCRIPTION
This change will mount EFS on $HOME. The first time a user logs in, the user's EFS directory will be created, along with appropriate directory structure within.

Along with this, I had to move ~/.bashrc code to a "global" .sh file, which runs whenever a user logs in. This way we can keep changing what we put in there without it messing with the user's .bashrc file.

Examples are downloaded on first login, and if EFS is not mounted. With the current implementation, examples will not be updated. We can always add examples later, as a one-off on existing directories, and then adding it to newly created dirs in this code. (Though in general I'm against making changes to a user's dir.)

I've tested this as before:
1. A new user
2. An existing user
3. Without EFS mounting (--email unset)

All three worked as expected. I tested Jupyter and Spark within each, running the longitudinal notebook.

I've requested all of you to review because this is *very* difficult to test, and small changes can affect things over time. I'm sure I missed some things.