### PR TITLE
Bug 1335228 - Change owner of Spark log to spark instead of hadoop user.

### DIFF
--- a/ansible/files/bootstrap/telemetry.sh
+++ b/ansible/files/bootstrap/telemetry.sh
@@ -116,6 +116,7 @@ fi
 sudo mkdir -p /mnt/var/log/spark
 sudo chmod a+rw /mnt/var/log/spark
 touch /mnt/var/log/spark/spark.log
+sudo chown spark:spark /mnt/var/log/spark/spark.log
 
 # Setup R environment
 wget -nc https://mran.microsoft.com/install/RRO-3.2.1-el6.x86_64.tar.gz


### PR DESCRIPTION
If Spark is writing to the file using the "spark" user as indicated in the output Sam posted in [bug 1335228](https://bugzilla.mozilla.org/show_bug.cgi?id=1335228) then we should chown the logfile.