### PR TITLE
Bug 1344185 - Mount /home/hadoop on /mnt when not mounting efs

### DIFF
--- a/ansible/files/bootstrap/telemetry.sh
+++ b/ansible/files/bootstrap/telemetry.sh
@@ -87,6 +87,10 @@ if [ -n "$EMAIL" ] && [ -n "$EFS_DNS" ] && "$IS_MASTER" ; then
     sudo chmod 700 "$HOME/.ssh/authorized_keys"
 
 elif "$IS_MASTER" ; then
+    # if non-efs, mount $HOME on /mnt
+    cp -r -p /home/hadoop /mnt
+    sudo mount --bind --verbose /mnt/hadoop /home/hadoop
+
     mkdir -p $HOME/analyses
     SETUP_HOME_DIR=true
 fi


### PR DESCRIPTION
I've tested this on a cluster and it is mounting properly.

@jasonthomas r?