### PR TITLE
Update deprecated option name

### DIFF
--- a/ansible/files/configuration/configuration.json
+++ b/ansible/files/configuration/configuration.json
@@ -21,7 +21,7 @@
       "spark.local.dir": "/mnt,/mnt1",
       "spark.driver.maxResultSize": "4g",
       "spark.driver.memory": "4g",
-      "spark.akka.frameSize": "512",
+      "spark.rpc.message.maxSize": "512",
       "spark.serializer": "org.apache.spark.serializer.KryoSerializer",
       "spark.sql.sources.partitionColumnTypeInference.enabled": "false",
       "spark.kryoserializer.buffer.max": "256m"


### PR DESCRIPTION
As of Spark 1.6, the `spark.akka.frameSize` option is deprecated, and code should
use the `spark.rpc.message.maxSize` option instead. This avoids breakage if and
when the old option is removed.

This should avoid warnings like:
```
17/03/16 13:50:24 WARN SparkConf: The configuration key 'spark.akka.frameSize' has been deprecated as of Spark 1.6 and may be removed in the future. Please use the new key 'spark.rpc.message.maxSize' instead.
```

Note: This change is untested because I have no idea how to test it.