### PR TITLE
Update README with updated location of credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ aws emr create-cluster \
 ansible-playbook ansible/deploy.yml -e '@ansible/envs/production.yml' -i ansible/inventory
 ```
 
-The Spark Jupyter notebook configuration is hosted at `https://s3-us-west-2.amazonaws.com/telemetry-spark-emr-2/jupyter_notebook_config.py`. At the moment, this is only needed for the GitHub Gist export option in the Jupyter notebook. The credentials it contains are managed under the [Mozilla GitHub account](https://github.com/mozilla/) by :whd. This file **should not be made public**.
+The Spark Jupyter notebook configuration is hosted at `https://s3-us-west-2.amazonaws.com/telemetry-spark-emr-2/credentials/jupyter_notebook_config.py`. At the moment, this is only needed for the GitHub Gist export option in the Jupyter notebook. The credentials it contains are managed under the [Mozilla GitHub account](https://github.com/mozilla/) by :whd. This file **should not be made public**.


### PR DESCRIPTION
To provide more context... we've added a staging EMR bucket. To avoid clutter in the S3 bucket a `/credentials/` folder was created for all credential files to more easily identify what these files are and to contain the sensitive files in a single location.

This updates the README to match.