### PR TITLE
 Bug 1390332 - Set spark.scheduler.mode to FAIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This packages contains the AWS bootstrap scripts for Mozilla's flavoured Spark s
 ```bash
 export SPARK_PROFILE=telemetry-spark-cloudformation-TelemetrySparkInstanceProfile-1SATUBVEXG7E3
 export SPARK_BUCKET=telemetry-spark-emr-2
-export KEY_NAME=mozilla_vitillo
+export KEY_NAME=20161025-dataops-dev
 aws emr create-cluster \
   --region us-west-2 \
   --name SparkCluster \

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -41,6 +41,7 @@
         - bootstrap/telemetry.sh
         - bootstrap/python-requirements.txt
         - bootstrap/python3-requirements.txt
+        - bootstrap/fairscheduler.xml
 
     - name: copy public EMR files
       include: render_and_copy_to_s3.yml file={{item}} permission="public-read"

--- a/ansible/files/bootstrap/fairscheduler.xml
+++ b/ansible/files/bootstrap/fairscheduler.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!--
+    Bug 1390332 - Analysis clusters generally have a short lifespan and are
+    not used in a multi-tenant fashion. However, a resource pool under a
+    fair-scheduling policy enables sharing resources between short and long
+    running queries. See the related job scheduling documentation for
+    configuring pool properties.
+
+    https://spark.apache.org/docs/latest/job-scheduling.html#configuring-pool-properties
+-->
+<allocations>
+    <pool name="default">
+        <schedulingMode>FAIR</schedulingMode>
+        <weight>1</weight>
+        <minShare>2</minShare>
+    </pool>
+</allocations>

--- a/ansible/files/bootstrap/telemetry.sh
+++ b/ansible/files/bootstrap/telemetry.sh
@@ -204,18 +204,18 @@ sudo chown hadoop:hadoop "$GLOBAL_BASHRC"
 sudo chmod 700 "$GLOBAL_BASHRC"
 
 # Configure environment variables
-sudo echo "" >> "$GLOBAL_BASHRC"
-sudo echo "export R_LIBS=$HOME/R_libs" >> "$GLOBAL_BASHRC"
-sudo echo "export LD_LIBRARY_PATH=/usr/lib64/RRO-3.2.1/R-3.2.1/lib64/R/lib/" >> "$GLOBAL_BASHRC"
-sudo echo "export PYTHONPATH=/usr/lib/spark/python/" >> "$GLOBAL_BASHRC"
-sudo echo "export SPARK_HOME=/usr/lib/spark" >> "$GLOBAL_BASHRC"
-sudo echo "export PYSPARK_PYTHON=$ANACONDA_PATH/bin/python" >> "$GLOBAL_BASHRC"
-sudo echo "export PYSPARK_DRIVER_PYTHON=jupyter" >> "$GLOBAL_BASHRC"
-sudo echo "export PYSPARK_DRIVER_PYTHON_OPTS=console" >> "$GLOBAL_BASHRC"
-sudo echo "export PATH=$ANACONDA_PATH/bin:\$PATH" >> "$GLOBAL_BASHRC"
-sudo echo "export _JAVA_OPTIONS=\"-Djava.io.tmpdir=/mnt1/ -Xmx$DRIVER_MEMORY -Xms$DRIVER_MIN_HEAP\"" >> "$GLOBAL_BASHRC"
-sudo echo "export PYSPARK_SUBMIT_ARGS=\"--packages com.databricks:spark-csv_2.10:1.2.0 --master yarn --deploy-mode client --executor-memory $EXECUTOR_MEMORY --conf spark.yarn.executor.memoryOverhead=$MEMORY_OVERHEAD pyspark-shell\"" >> "$GLOBAL_BASHRC"
-sudo echo "export HIVE_SERVER={{metastore_dns}}" >> "$GLOBAL_BASHRC"
+sudo tee -a ${GLOBAL_BASHRC} <<EOF
+export R_LIBS=$HOME/R_libs
+export LD_LIBRARY_PATH=/usr/lib64/RRO-3.2.1/R-3.2.1/lib64/R/lib/
+export PYTHONPATH=/usr/lib/spark/python/
+export SPARK_HOME=/usr/lib/spark
+export PYSPARK_PYTHON=$ANACONDA_PATH/bin/python
+export PYSPARK_DRIVER_PYTHON=jupyter
+export PYSPARK_DRIVER_PYTHON_OPTS=console
+export PATH=$ANACONDA_PATH/bin:$PATH
+export _JAVA_OPTIONS="-Djava.io.tmpdir=/mnt1/ -Xmx$DRIVER_MEMORY -Xms$DRIVER_MIN_HEAP"
+export HIVE_SERVER={{metastore_dns}}
+EOF
 
 source "$GLOBAL_BASHRC"
 


### PR DESCRIPTION
# [Bug 1390332 - Set spark.scheduler.mode to FAIR](https://bugzilla.mozilla.org/show_bug.cgi?id=1390332)

This sets the default ATMO scheduler to FAIR allows for multiple jobs and notebooks to run in Jupyter. This also makes reading global environment variables easier by using `sudo tee` instead of `sudo echo $line`.

### Notes to self
- [x] Create a new ansible environment `env/amiyaguchi.yml`
  * `spark_emr_bucket: telemetry-spark-emr-2-amiyaguchi`
  * `stack_name: telemetry-spark-cloudformation-dev-amiyaguchi` (sorry for messing up stage)
  * Recursively copy staging assets into new bucket
  * Deploy local assets using `ansible-playbook`
  * Ansible deploy script creates an EFS volume, but token to create it is shared by the staging environment -- I *probably* don't have to worry about it
- [x] Use virtualenv to run the deploy script: `pip install ansible boto boto3`
-  [x] Create PR for handling virtualenv python path in `ansible-playbook`
- [x] Update `README.md` with new security `KEY_NAME` 
- [x] recursive copy staging assets into new bucket because of bootstrapping failure
  * This may not be entirely necessary, because bootstrapping failures were actually caused by using the wrong cloudformation profile (the default `SPARK_PROFILE` points to the profile generated for a given stack)
- [x] successfully launch into new environment
  * Set `SPARK_PROFILE` to cloudformation instance profile (check cf dashboard)
    - ` aws cloudformation describe-stacks --stack-name telemetry-spark-cloudformation-dev-amiyaguchi | jq '.Stacks[0].Outputs[0].OutputValue'`
  * Set `SPARK_BUCKET` to new emr bucket
- [x] check `sc._conf.get("spark.scheduler.mode")` returns `"FAIR"`
- [x] Add `spark.scheduler.allocation.file` to avoid using the default pool
~~test that I can run two notebooks side by side :(~~
