### PR TITLE
Set ansible_python_intepreter=python in local inventory

### DIFF
--- a/ansible/inventory/hosts
+++ b/ansible/inventory/hosts
@@ -1,0 +1,3 @@
+[localhost]
+localhost ansible_connection=local
+localhost ansible_python_interpreter=python


### PR DESCRIPTION
Ansible assumes the default intepreter is python 2 at /usr/bin/python.
If you use virtual environments, then the deploy script will fail. The
first line prevents ansible from using ssh to access localhost; the
second line sets the intepreter to the current python set in the path.

* http://docs.ansible.com/ansible/latest/faq.html#how-do-i-handle-python-pathing-not-having-a-python-2-x-in-usr-bin-python-on-a-remote-machine
* https://www.zigg.com/2014/using-virtualenv-python-local-ansible.html
* http://docs.ansible.com/ansible/latest/intro_inventory.html#non-ssh-connection-types