### PR TITLE
Update README with setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This packages contains the AWS bootstrap scripts for Mozilla's flavoured Spark s
 ```bash
 export SPARK_PROFILE=telemetry-spark-cloudformation-TelemetrySparkInstanceProfile-1SATUBVEXG7E3
 export SPARK_BUCKET=telemetry-spark-emr-2
-export KEY_NAME=mozilla_vitillo
+export KEY_NAME=20161025-dataops-dev
 aws emr create-cluster \
   --region us-west-2 \
   --name SparkCluster \

--- a/README.md
+++ b/README.md
@@ -48,3 +48,30 @@ ansible-playbook ansible/deploy.yml -e '@ansible/envs/production.yml' -i ansible
 ```
 
 The Spark Jupyter notebook configuration is hosted at `https://s3-us-west-2.amazonaws.com/telemetry-spark-emr-2/credentials/jupyter_notebook_config.py`. At the moment, this is only needed for the GitHub Gist export option in the Jupyter notebook. The credentials it contains are managed under the [Mozilla GitHub account](https://github.com/mozilla/) by :whd. This file **should not be made public**.
+
+
+## Contributing to `emr-bootstrap-spark`
+
+You may set up a development environment to test and verify modifications applied to this repository.
+
+### Install prerequisite packages
+```
+pip install ansible boto boto3
+```
+
+### Create and bootstrap the development environment
+* Define a new ansible environment in `env/username.yml`
+    * Set `spark_emr_bucket` to a unique bucket e.g. `telemetry-spark-emr-2-dev-username`
+    * Set `stack_name` to a unique name e.g. `telemetry-spark-cloudformation-dev-username`
+* Recursively copy assets from `staging` to `dev`
+    * `aws s3 cp --recursive s3://telemetry-spark-emr-2-stage s3://telemetry-spark-emr-2-dev-username`
+* Deploy to AWS using `ansible-playbook` on the new environment
+* Launch a new instance using the appropriate `SPARK_PROFILE` and `SPARK_BUCKET` keys
+    * Set `SPARK_PROFILE` to the cloudformation instance profile
+        * This can be found as an output on the cloudformation dashboard
+        * Alternatively:
+            ```
+               aws cloudformation describe-stacks --stack-name telemetry-spark-cloudformation-dev-username |
+               jq '.Stacks[0].Outputs[0].OutputValue'
+            ```
+    * Set `SPARK_BUCKET` to `spark_emr_bucket` value in `env/username.yml`

--- a/README.md
+++ b/README.md
@@ -60,18 +60,18 @@ pip install ansible boto boto3
 ```
 
 ### Create and bootstrap the development environment
-* Define a new ansible environment in `env/username.yml`
-    * Set `spark_emr_bucket` to a unique bucket e.g. `telemetry-spark-emr-2-dev-username`
-    * Set `stack_name` to a unique name e.g. `telemetry-spark-cloudformation-dev-username`
+* Define a new ansible environment in `env/dev-<username>.yml`
+    * Set `spark_emr_bucket` to a unique bucket e.g. `telemetry-spark-emr-2-dev-<username>`
+    * Set `stack_name` to a unique name e.g. `telemetry-spark-cloudformation-dev-<username>`
 * Recursively copy assets from `staging` to `dev`
-    * `aws s3 cp --recursive s3://telemetry-spark-emr-2-stage s3://telemetry-spark-emr-2-dev-username`
+    * `aws s3 cp --recursive s3://telemetry-spark-emr-2-stage s3://telemetry-spark-emr-2-dev-<username>`
 * Deploy to AWS using `ansible-playbook` on the new environment
 * Launch a new instance using the appropriate `SPARK_PROFILE` and `SPARK_BUCKET` keys
     * Set `SPARK_PROFILE` to the cloudformation instance profile
         * This can be found as an output on the cloudformation dashboard
         * Alternatively:
             ```
-               aws cloudformation describe-stacks --stack-name telemetry-spark-cloudformation-dev-username |
+               aws cloudformation describe-stacks --stack-name telemetry-spark-cloudformation-dev-<username> |
                jq '.Stacks[0].Outputs[0].OutputValue'
             ```
-    * Set `SPARK_BUCKET` to `spark_emr_bucket` value in `env/username.yml`
+    * Set `SPARK_BUCKET` to `spark_emr_bucket` value in `env/dev-<username>.yml`

--- a/ansible/files/bootstrap/telemetry.sh
+++ b/ansible/files/bootstrap/telemetry.sh
@@ -204,18 +204,18 @@ sudo chown hadoop:hadoop "$GLOBAL_BASHRC"
 sudo chmod 700 "$GLOBAL_BASHRC"
 
 # Configure environment variables
-sudo echo "" >> "$GLOBAL_BASHRC"
-sudo echo "export R_LIBS=$HOME/R_libs" >> "$GLOBAL_BASHRC"
-sudo echo "export LD_LIBRARY_PATH=/usr/lib64/RRO-3.2.1/R-3.2.1/lib64/R/lib/" >> "$GLOBAL_BASHRC"
-sudo echo "export PYTHONPATH=/usr/lib/spark/python/" >> "$GLOBAL_BASHRC"
-sudo echo "export SPARK_HOME=/usr/lib/spark" >> "$GLOBAL_BASHRC"
-sudo echo "export PYSPARK_PYTHON=$ANACONDA_PATH/bin/python" >> "$GLOBAL_BASHRC"
-sudo echo "export PYSPARK_DRIVER_PYTHON=jupyter" >> "$GLOBAL_BASHRC"
-sudo echo "export PYSPARK_DRIVER_PYTHON_OPTS=console" >> "$GLOBAL_BASHRC"
-sudo echo "export PATH=$ANACONDA_PATH/bin:\$PATH" >> "$GLOBAL_BASHRC"
-sudo echo "export _JAVA_OPTIONS=\"-Djava.io.tmpdir=/mnt1/ -Xmx$DRIVER_MEMORY -Xms$DRIVER_MIN_HEAP\"" >> "$GLOBAL_BASHRC"
-sudo echo "export PYSPARK_SUBMIT_ARGS=\"--packages com.databricks:spark-csv_2.10:1.2.0 --master yarn --deploy-mode client --executor-memory $EXECUTOR_MEMORY --conf spark.yarn.executor.memoryOverhead=$MEMORY_OVERHEAD pyspark-shell\"" >> "$GLOBAL_BASHRC"
-sudo echo "export HIVE_SERVER={{metastore_dns}}" >> "$GLOBAL_BASHRC"
+sudo tee -a ${GLOBAL_BASHRC} <<EOF
+export R_LIBS=$HOME/R_libs
+export LD_LIBRARY_PATH=/usr/lib64/RRO-3.2.1/R-3.2.1/lib64/R/lib/
+export PYTHONPATH=/usr/lib/spark/python/
+export SPARK_HOME=/usr/lib/spark
+export PYSPARK_PYTHON=$ANACONDA_PATH/bin/python
+export PYSPARK_DRIVER_PYTHON=jupyter
+export PYSPARK_DRIVER_PYTHON_OPTS=console
+export PATH=$ANACONDA_PATH/bin:$PATH
+export _JAVA_OPTIONS="-Djava.io.tmpdir=/mnt1/ -Xmx$DRIVER_MEMORY -Xms$DRIVER_MIN_HEAP"
+export HIVE_SERVER={{metastore_dns}}
+EOF
 
 source "$GLOBAL_BASHRC"
 


### PR DESCRIPTION
Separating out the uncontroversial bits from issue #113 

* Updates the README with easy to follow steps to set up a development environment
* Removes `ipython` leftovers - `PYSPARK_SUBMIT_ARGS`