### PR TITLE
Add Jupyter contributor extensions and extensions UI

### DIFF
--- a/ansible/files/bootstrap/telemetry.sh
+++ b/ansible/files/bootstrap/telemetry.sh
@@ -221,6 +221,10 @@ source "$GLOBAL_BASHRC"
 
 
 # Configure Jupyter
+
+$ANACONDA_PATH/bin/pip install jupyter_contrib_nbextensions jupyter_nbextensions_configurator
+jupyter nbextensions_configurator enable --user
+
 jupyter nbextension enable --py widgetsnbextension --user
 
 jupyter serverextension enable --py jupyter_notebook_gist --user


### PR DESCRIPTION
This adds the Jupyter [contributor extensions package](https://github.com/ipython-contrib/jupyter_contrib_nbextensions) and an [UI for configuring extensions](https://github.com/Jupyter-contrib/jupyter_nbextensions_configurator#usage). See the second link for screenshots.

The UI allows users to enable or disable individual extensions and to configure their settings. These settings are saved in dotfiles in the home directory, which means they are persistent. If I configured an extension, my cluster is stopped and I spawn a new cluster, the settings will still be there.

The contributor extensions package is nice to have because it comes with some useful extensions that we don't seem to have available so far.