### PR TITLE
Pin python_moztelemetry in bootstrap

### DIFF
--- a/ansible/files/bootstrap/python-requirements.txt
+++ b/ansible/files/bootstrap/python-requirements.txt
@@ -11,7 +11,7 @@ protobuf==3.1.0
 py4j==0.8.2.1
 pyliblzma==0.5.3
 python-mozaggregator==0.3.0.1
-python_moztelemetry>=0.5,<1.0.0
+python_moztelemetry==0.9.1
 seaborn==0.6.0
 pyarrow==0.7.1
 feather-format==0.4.0


### PR DESCRIPTION
So that we can release a new version for python_moztelemetry without breaking ATMO jobs if there's an unexpected bug

r? @robotblake or @jasonthomas 